### PR TITLE
Problem with add new Widget Groups

### DIFF
--- a/page-builder/widget-groups.md
+++ b/page-builder/widget-groups.md
@@ -11,7 +11,7 @@ function mytheme_add_widget_tabs($tabs) {
 	$tabs[] = array(
 		'title' => __('My Tab', 'mytheme'),
 		'filter' => array(
-			'groups' => array('mytheme')
+			'groups' => 'mytheme'
 		)
 	);
 	


### PR DESCRIPTION
I have tried to add a new Group following the tutorial: https://siteorigin.com/docs/page-builder/widget-groups/. However, the Widget Groups's title appear but when I click to it, there are nothing show up.  

I found that  when I change `'groups' => array('mytheme')` to `'groups' => 'mytheme'`, everthing works perfectly!
