### PR TITLE
Update bundling-prebuilt.md to clarify where the data dump will show up

### DIFF
--- a/page-builder/bundling-prebuilt.md
+++ b/page-builder/bundling-prebuilt.md
@@ -13,7 +13,7 @@ define('SITEORIGIN_PANELS_DEV', true);
 
 ### Page Builder Data Dump
 
-After you've enabled debug mode, you'll get a full dump of your page's content as a PHP array. To do this, view the HTML source of a page builder page you've already created. Then search for the following string `Page Builder Data`. You'll see a standard HTML comment with the PHP for your page. Copy this array, we'll be using it shortly.
+After you've enabled debug mode, you'll get a full dump of your page's content as a PHP array. To do this, view the HTML source of a page builder page you've already created. **Attention: The dump will only show up when you are editing the page you created with SiteBuilder, but not when you simply view it.** Then search for the following string `Page Builder Data`. You'll see a standard HTML comment with the PHP for your page. Copy this array, we'll be using it shortly.
 
 ### Registering Your Prebuilt Layout
 


### PR DESCRIPTION
Clarify that the data dump will only show up in the page editor source, not in the page view source. Almost went crazy for 15min until I found the answer in this thread: https://wordpress.org/support/topic/for-developers-how-to-include-prebuilt-layouts-in-theme

Should also be mentioned in the official docs :-)