### PR TITLE
Added mention of screenshot to Prebuilt Layout docs

### DIFF
--- a/page-builder/bundling-prebuilt.md
+++ b/page-builder/bundling-prebuilt.md
@@ -25,6 +25,7 @@ function mytheme_prebuilt_layouts($layouts){
 		// We'll add a title field
 		'name' => __('Default Home', 'vantage'),	// Required
 		'description' => __('Default Home Description', 'vantage'),	// Optional
+		'screenshot' => plugin_dir_url( __FILE__ ) . 'images/layout-screenshot.png',	// Optional
 		'widgets' => array( ... ),
 		'grids' => array( ... ),
 		'grid_cells' => array( ... )


### PR DESCRIPTION
There was previously no mention of a screenshot. I've included plugin_dir_url() to directly reference the URL to prevent issues but, obviously, that could be adjusted if need be.