### PR TITLE
Directly reference plugin directory

### DIFF
--- a/widgets-bundle/form-building/icons-and-fonts.md
+++ b/widgets-bundle/form-building/icons-and-fonts.md
@@ -19,7 +19,7 @@ To filter the icon families, you use the `'siteorigin_widgets_icon_families'` fi
 function my_icon_families_filter( $icon_families ) {
     $icon_families['my-rad-icon-family'] = array(
 		'name' => __( 'My Rad Icons', 'example-text-domain' ),
-		'style_uri' => 'path/to/my/rad/icons/style.css',
+		'style_uri' => plugin_dir_url( __FILE__ ) . '/icons/style.css',
 		'icons' => array(
 		    'my-rad-search-icon' => '&#xf101;',
 		    'my-rad-close-icon' => '&#xf101;'


### PR DESCRIPTION
Changed the style_uri to a directly referenced path to prevent users who are copying and pasting it from having to work out how to do this.