### PR TITLE
Correct incorrect example code

### DIFF
--- a/widgets-bundle/form-building/icons-and-fonts.md
+++ b/widgets-bundle/form-building/icons-and-fonts.md
@@ -17,7 +17,7 @@ To filter the icon families, you use the `'siteorigin_widgets_icon_families'` fi
 
 ```php
 function my_icon_families_filter( $icon_families ) {
-    $icon_families['my-rad-icon-family'] = array(
+    $icon_families['radicons'] = array(
 		'name' => __( 'My Rad Icons', 'example-text-domain' ),
 		'style_uri' => plugin_dir_url( __FILE__ ) . '/icons/style.css',
 		'icons' => array(


### PR DESCRIPTION
I'm unsure if it's intended or not, but you're unable to use hyphens in the icon family name ([ref](https://siteorigin.slack.com/archives/plugins/p1473791658000089)). So to prevent errors (for at least the time being), we should remove it from the example code.