### PR TITLE
Fix url to initialising

### DIFF
--- a/widgets-bundle/advanced-concepts/actions/enqueue-admin-scripts.md
+++ b/widgets-bundle/advanced-concepts/actions/enqueue-admin-scripts.md
@@ -1,6 +1,6 @@
 # Enqueue admin scripts action
 
-This action gives you a chance to enqueue any additional admin scripts and styles for a widget. If you need to enqueue scripts for your custom widgets, you can read about that in our getting started section on [initializing a widget](../../getting-started/initializing-a-widget.md). This action is mainly for enqueuing additional scripts and styles for a widget that you're extending.
+This action gives you a chance to enqueue any additional admin scripts and styles for a widget. If you need to enqueue scripts for your custom widgets, you can read about that in our getting started section on [initialising a widget](../../getting-started/initialising-a-widget.md). This action is mainly for enqueuing additional scripts and styles for a widget that you're extending.
 
 This action has the form `'siteorigin_widgets_enqueue_admin_scripts_' . $this->id_base` and `'siteorigin_widgets_enqueue_admin_scripts'`. The version with the id_base is designed to target a specific widget.
 


### PR DESCRIPTION
"Initialising a widget" sent the user to the wrong page: `../../getting-started/initializing-a-widget.md`