### PR TITLE
siteorigin_panels_general_current_styles

### DIFF
--- a/page-builder/hooks/custom-row-settings.md
+++ b/page-builder/hooks/custom-row-settings.md
@@ -88,7 +88,7 @@ To add a new attribute, add both a new key and value to ``$attributes``. Example
 Note that the filter for ``siteorigin_panels_row_style_attributes`` needs to be called after Page Builder loads. In my project I added the filter inside a function which is triggered on ``plugins_loaded``.
 
 ### Processing Styles
-Prior to rendering the contexts styles, it's possible to access and alter styles of the current context using filters. This allows for you to migrate and alter data as needed. Changes aren't however stored until the user saves the page/widget. There is two filters that allow for this. `siteorigin_panels_general_current_styles`, which is a general catch all filter, and `siteorigin_panels_general_current_styles_{type}`, `{type}` being the currently viewed type.
+Before rendering the context's styles, it's possible to access and alter the styles of the current context using filters. This allows you to migrate and alter data as needed. Changes aren't, however, stored until the user saves the page/widget. There are two filters that allow for this. siteorigin_panels_general_current_styles, which is a general catch-all filter, and siteorigin_panels_general_current_styles_{type}, {type} being the currently viewed type.
 
 #### Parameters:
 **current**
@@ -97,7 +97,7 @@ An array containing the current settings for the type.
 
 **post_id**
 
-The id of post being edited. This value will be empty if edited outside of the Page Builder.
+The id of post being edited. This value will be empty if edited outside of Page Builder.
 
 **type**
 
@@ -105,4 +105,4 @@ The current type. This parammater is not present if `siteorigin_panels_general_c
 
 **args**
 
-An array containing builder Arguments.
+An array containing builder arguments.

--- a/page-builder/hooks/custom-row-settings.md
+++ b/page-builder/hooks/custom-row-settings.md
@@ -16,7 +16,7 @@ function custom_row_style_fields($fields) {
 add_filter( 'siteorigin_panels_row_style_fields', 'custom_row_style_fields' );
 ```
 
-####Parameters:
+#### Parameters:
 
 **name**
 
@@ -86,3 +86,23 @@ To add a custom style (like text-align: center;), append the style to ``$attribu
 To add a new attribute, add both a new key and value to ``$attributes``. Example: ``$attributes['data-video-id'] = $args['video-id'];`` will add ``data-video-id="9"`` to the row element.
 
 Note that the filter for ``siteorigin_panels_row_style_attributes`` needs to be called after Page Builder loads. In my project I added the filter inside a function which is triggered on ``plugins_loaded``.
+
+### Processing Styles
+Prior to rendering the contexts styles, it's possible to access and alter styles of the current context using filters. This allows for you to migrate and alter data as needed. Changes aren't however stored until the user saves the page/widget. There is two filters that allow for this. `siteorigin_panels_general_current_styles`, which is a general catch all filter, and `siteorigin_panels_general_current_styles_{type}`, `{type}` being the currently viewed type.
+
+#### Parameters:
+**current**
+
+An array containing the current settings for the type.
+
+**post_id**
+
+The id of post being edited. This value will be empty if edited outside of the Page Builder.
+
+**type**
+
+The current type. This parammater is not present if `siteorigin_panels_general_current_styles_{type}` is the used filter.
+
+**args**
+
+An array containing builder Arguments.


### PR DESCRIPTION
Introduced in PB 2.12.0 to handle migration Parallax (Original Size) to simply Parallax. Added in https://github.com/siteorigin/siteorigin-panels/pull/782/commits/45032033608787709345f39d9d9ffc7a9278d353