### PR TITLE
Form Field multi measurement: Rename option for consistency

### DIFF
--- a/widgets-bundle/form-building/form-fields.md
+++ b/widgets-bundle/form-building/form-fields.md
@@ -163,7 +163,7 @@ $form_options = array(
 		'autofill' => true,
 		'default' => '5% 0px 25px 0px',
 		'measurements' => array(
-			'padding_top' => array(
+			'top' => array(
 				'label' => __( 'Padding Top', 'widget-form-fields-text-domain' ),
 				'units' => $useable_units,
 			),


### PR DESCRIPTION
The other values are without padding in the field name so this PR will make the Padding Top setting consistent with the other options.