### PR TITLE
Row column defaults row columns and column input filters

### DIFF
--- a/page-builder/hooks/custom-row-settings.md
+++ b/page-builder/hooks/custom-row-settings.md
@@ -106,3 +106,25 @@ The current type. This parammater is not present if `siteorigin_panels_general_c
 **args**
 
 An array containing builder arguments.
+
+### Altering the Default Number of Columns for Rows
+
+It's possible to override the default number of row columns, and their weight (width), by using the `siteorigin_panels_default_row_columns` filter. This filter accepts a multidimensional array with each item being treated as a column. Each item must contain a weight item which is used to size the column. Weight is decimal based so 0.30 is equivalent to 30% of the row.
+
+The following snippet will allow you to set the default
+
+```php
+add_filter( 'siteorigin_panels_default_row_columns', function( $default_columns ) {
+	return array(
+		array(
+			'weight' => 0.333,
+		),
+		array(
+			'weight' => 0.333,
+		),
+		array(
+			'weight' => 0.333,
+		),
+	);
+} );
+```

--- a/page-builder/hooks/custom-row-settings.md
+++ b/page-builder/hooks/custom-row-settings.md
@@ -111,7 +111,7 @@ An array containing builder arguments.
 
 It's possible to override the default number of row columns, and their weight (width), by using the `siteorigin_panels_default_row_columns` filter. This filter accepts a multidimensional array with each item being treated as a column. Each item must contain a weight item which is used to size the column. Weight is decimal based so 0.30 is equivalent to 30% of the row.
 
-The following snippet will allow you to set the default
+The following snippet will allow you to set the default:
 
 ```php
 add_filter( 'siteorigin_panels_default_row_columns', function( $default_columns ) {

--- a/page-builder/hooks/custom-row-settings.md
+++ b/page-builder/hooks/custom-row-settings.md
@@ -128,3 +128,15 @@ add_filter( 'siteorigin_panels_default_row_columns', function( $default_columns 
 	);
 } );
 ```
+
+### Override the Row Column Input
+
+It's possible to adjust the Row Column input markup by using the `siteorigin_panels_row_column_count_input` filter. This will allow alter the column number present in the input field. It doesn't however allow you to alter the default row columns, that's done using `siteorigin_panels_default_row_columns` filter.
+
+The following snippet will column the column field to 4.
+
+```php
+add_filter( 'siteorigin_panels_row_column_count_input', function( $input ) {
+	return '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="4" />';
+} );
+```


### PR DESCRIPTION
This PR adds documentation for the following filters:
`siteorigin_panels_default_row_columns`
`siteorigin_panels_row_column_count_input`

Related:
https://github.com/siteorigin/siteorigin-panels/pull/892
https://github.com/siteorigin/siteorigin-panels/pull/888