### PR TITLE
SITEORIGIN_WIDGETS_DEBUG & siteorigin_widgets_less_vars

### DIFF
--- a/widgets-bundle/advanced-concepts/filters/less-content.md
+++ b/widgets-bundle/advanced-concepts/filters/less-content.md
@@ -1,6 +1,6 @@
 # LESS content filter
 
-You're able to access a widgets LESS prior to it being converted to CSS by using the `'siteorigin_widgets_less_' . $this->id_base` filter. This filter runs _after_ the LESS variables from the widget instance have been injected.
+You're able to access a widget's LESS prior to it being converted to CSS by using the `'siteorigin_widgets_less_' . $this->id_base` filter. This filter runs _after_ the LESS variables from the widget instance have been injected.
 
 ```php
 /**
@@ -9,8 +9,8 @@ You're able to access a widgets LESS prior to it being converted to CSS by using
  * @param SiteOrigin_Widget $widget The widget object.
  */
 function wbe_filter_widget_less( $less, $instance, $widget ) {
-    // Filter the LESS content here.
-    return $less;
+	// Filter the LESS content here.
+	return $less;
 }
 add_filter('siteorigin_widgets_less_sow-button', 'wbe_filter_widget_less', 10, 3);
 ```
@@ -25,8 +25,8 @@ If you want to make changes to the LESS prior to the variables being replaced, y
  * @param SiteOrigin_Widget $widget The widget object.
  */
 function wbe_filter_widget_less_vars( $less, $vars, $instance, $widget ) {
-    // Filter the LESS content here.
-    return $less;
+	// Filter the LESS content here.
+	return $less;
 }
 add_filter( 'siteorigin_widgets_less_vars_sow-button', 'wbe_filter_widget_less_vars', 10, 4 );
 ```

--- a/widgets-bundle/advanced-concepts/filters/less-content.md
+++ b/widgets-bundle/advanced-concepts/filters/less-content.md
@@ -1,8 +1,6 @@
 # LESS content filter
 
-This filter gives you raw access to the content of the LESS style file before the Widgets Bundle converts it into CSS. This filter runs after the LESS variables from the widget instance have been injected.
-
-The filter takes the form `'siteorigin_widgets_less_' . $this->id_base`.
+You're able to access a widgets LESS prior to it being converted to CSS by using the `'siteorigin_widgets_less_' . $this->id_base` filter. This filter runs _after_ the LESS variables from the widget instance have been injected.
 
 ```php
 /**
@@ -16,3 +14,21 @@ function wbe_filter_widget_less( $less, $instance, $widget ) {
 }
 add_filter('siteorigin_widgets_less_sow-button', 'wbe_filter_widget_less', 10, 3);
 ```
+
+If you want to make changes to the LESS prior to the variables being replaced, you can use the `siteorigin_widgets_less_vars_' . $this->id_base` instead.
+
+```php
+/**
+ * @param string $less The LESS content.
+ * @param array $vars The widget LESS variables.
+ * @param array $instance The widget instance.
+ * @param SiteOrigin_Widget $widget The widget object.
+ */
+function wbe_filter_widget_less_vars( $less, $vars, $instance, $widget ) {
+    // Filter the LESS content here.
+    return $less;
+}
+add_filter( 'siteorigin_widgets_less_vars_sow-button', 'wbe_filter_widget_less_vars', 10, 4 );
+```
+
+Please note that `siteorigin_widgets_less_vars_' . $this->id_base` is run after WB has run all LESS `.widget-function()` callbacks and processed all LESS @imports.

--- a/widgets-bundle/templating/less-stylesheets.md
+++ b/widgets-bundle/templating/less-stylesheets.md
@@ -2,7 +2,7 @@
 
 For easier development of styles and runtime stylesheet generation the Widgets Bundle uses LESS. A LESS stylesheet may be specified by overriding the `get_style_name()` function and returning the name of the file, without the `.less` extension, found in the `styles` folder.
 
-Once the widgets LESS stylesheets are generated, they'll be cached at `wp-content/uploads/siteorigin-widgets/`. You can prevent this to make testing LESS simpler by adding the following to your `wp-config.php` file:
+Once the widget's LESS stylesheets are generated, they'll be cached at `wp-content/uploads/siteorigin-widgets/`. You can prevent this to make testing LESS simpler by adding the following to your `wp-config.php` file:
 
 `define( 'SITEORIGIN_WIDGETS_DEBUG', true );`
 

--- a/widgets-bundle/templating/less-stylesheets.md
+++ b/widgets-bundle/templating/less-stylesheets.md
@@ -1,5 +1,10 @@
 # LESS stylesheets
+
 For easier development of styles and runtime stylesheet generation the Widgets Bundle uses LESS. A LESS stylesheet may be specified by overriding the `get_style_name()` function and returning the name of the file, without the `.less` extension, found in the `styles` folder.
+
+Once the widgets LESS stylesheets are generated, they'll be cached at `wp-content/uploads/siteorigin-widgets/`. You can prevent this to make testing LESS simpler by adding the following to your `wp-config.php` file:
+
+`define( 'SITEORIGIN_WIDGETS_DEBUG', true );`
 
 ## Mixin libraries
 For convenience, we have included the mixin libraries, <a href="http://lesselements.com/" target="_blank">LESS Elements</a> and <a href="http://lesshat.madebysource.com/" target="_blank">LESSHat</a>, in the `base/less/` folder. They help reduce the amount of CSS required to ensure compatibility with multiple versions of multiple browsers, or where CSS is simply too verbose. See their respective documentation pages for more information on what's available and usage examples. These may be included in a LESS stylesheet by using the `@import` directive, as follows:


### PR DESCRIPTION
This PR adds the docs for [SITEORIGIN_WIDGETS_DEBUG](https://github.com/siteorigin/so-widgets-bundle/pull/1355) and `siteorigin_widgets_less_vars`. It partially does the latter by rewriting widgets-bundle/advanced-concepts/filters/less-content.md as that file was previously written with a single filter in mind rather than two.