### PR TITLE
Row and Widget Style Page adjustments & documenting setup_style_fields

### DIFF
--- a/page-builder.md
+++ b/page-builder.md
@@ -26,8 +26,8 @@ Page Builder has lots of hooks and filters for you to use. We've already covered
 
 - [Filtering HTML Structure](./page-builder/hooks/html.md).
 - [Filtering CSS](./page-builder/hooks/css.md).
-- [Filtering Custom Row Options](./page-builder/hooks/custom-row-settings.md).
-- [Filtering Widget Options](./page-builder/hooks/filtering-widget-settings.md)
+- [Filtering Custom Row Options](./page-builder/hooks/custom-row-styles.md).
+- [Filtering Widget Options](./page-builder/hooks/filtering-widget-styles.md)
 - [Filtering Widget Form](./page-builder/hooks/widget-form.md).
 - [Filtering Widget Instance](./page-builder/hooks/widget-instance.md).
 - [Filtering Page Builder Features and Actions](./page-builder/hooks/builder-features-actions.md).

--- a/page-builder/_sidebar.md
+++ b/page-builder/_sidebar.md
@@ -12,6 +12,7 @@
 - [HTML Structure](hooks/html.md)
 - [Page Builder Features and Actions](hooks/builder-features-actions.md)
 - [Override Row Collapse Point](hooks/override-row-collapse-point.md)
+- [Row Form](hooks/row-form.md)
 - [Widget Form](hooks/widget-form.md)
 - [Widget Instance](hooks/widget-instance.md)
 

--- a/page-builder/_sidebar.md
+++ b/page-builder/_sidebar.md
@@ -7,8 +7,8 @@
 ### Hooks
 
 - [CSS](hooks/css.md)
-- [Custom Row Options](hooks/custom-row-settings.md)
-- [Filtering Widget Options](hooks/filtering-widget-settings.md)
+- [Custom Row Options](hooks/filtering-row-styles.md)
+- [Filtering Widget Options](hooks/filtering-widget-styles.md)
 - [HTML Structure](hooks/html.md)
 - [Page Builder Features and Actions](hooks/builder-features-actions.md)
 - [Override Row Collapse Point](hooks/override-row-collapse-point.md)

--- a/page-builder/hooks.md
+++ b/page-builder/hooks.md
@@ -2,8 +2,8 @@
 
 - [Filtering Page Builder Features and Actions](hooks/builder-features-actions.md).
 - [Filtering CSS](hooks/css.md).
-- [Filtering Custom Row Options](hooks/custom-row-settings.md).
-- [Filtering Widget Options](hooks/filtering-widget-settings.md)
+- [Filtering Custom Row Options](hooks/filtering-row-styles.md).
+- [Filtering Widget Options](hooks/filtering-widget-styles.md)
 - [Filtering HTML Structure](hooks/html.md).
 - [Overriding Row Collapse Point](hooks/override-row-collapse-point.md)
 - [Filtering Widget Form](hooks/widget-form.md).

--- a/page-builder/hooks.md
+++ b/page-builder/hooks.md
@@ -6,5 +6,6 @@
 - [Filtering Widget Options](hooks/filtering-widget-styles.md)
 - [Filtering HTML Structure](hooks/html.md).
 - [Overriding Row Collapse Point](hooks/override-row-collapse-point.md)
+- [Filtering Row Form](hooks/row-form.md).
 - [Filtering Widget Form](hooks/widget-form.md).
 - [Filtering Widget Instance](hooks/widget-instance.md).

--- a/page-builder/hooks/filtering-row-styles.md
+++ b/page-builder/hooks/filtering-row-styles.md
@@ -106,3 +106,21 @@ The current type. This parameter is not present if `siteorigin_panels_general_cu
 **args**
 
 An array containing builder arguments.
+
+### JavaScript event: setup_style_fields
+
+The `setup_style_fields` event will allow you interact with styles, and make adjustments based on the overall Page Builder view. This can be used to help trigger JavaScript assoicated with custom fields (such as date picker) and conditionally show fields.
+
+For example, the following JavaScript will conditionally show a field with the id of `example` based on whether the `toggle_example` field is ticked or not.
+
+```javascript
+( function( $ ) {
+	$( document ).on( 'setup_style_fields', function( e, view ) {
+		var example = view.$el.find( '.so-field-example' );
+
+		view.$el.find( '.so-field-toggle_example input[type="checkbox"]' ).on( 'change', function() {
+			// If the toggle example field is checked, show the field.
+			$( this ).is( ':checked' ) ? exampleField.show() : exampleField.hide();
+		} ).trigger( 'change' );
+} )( jQuery );
+```

--- a/page-builder/hooks/filtering-row-styles.md
+++ b/page-builder/hooks/filtering-row-styles.md
@@ -24,11 +24,11 @@ The name of the custom option.
 
 **type**
 
-Can be set to ``checkbox``, ``text``, ``code``, ``measurement``, ``color``, ``image`` and ``select``.
+Can be set to `checkbox`, `text`, `code`, `measurement`, `color`, `image` and `select`.
 
 **group**
 
-Can be set to ``design``, ``layout`` and ``attributes``.
+Can be set to `design`, `layout` and `attributes`.
 
 **description**
 
@@ -40,23 +40,23 @@ The position in the group the option should appear. Priority set on default opti
 
 Attribute Fields
 
-* 5 - Row Class
-* 6 - Cell Class
-* 10 - CSS Styles
+- 5 - Row Class
+- 6 - Cell Class
+- 10 - CSS Styles
 
 Layout Fields
 
-* 5 - Bottom Margin
-* 6 - Gutter
-* 7 - Padding
-* 10 - Row Layout
+- 5 - Bottom Margin
+- 6 - Gutter
+- 7 - Padding
+- 10 - Row Layout
 
 Design Fields
 
-* 5 - Background Color
-* 6 - Background Image
-* 7 - Background Image Display
-* 10 - Border Color
+- 5 - Background Color
+- 6 - Background Image
+- 7 - Background Image Display
+- 10 - Border Color
 
 ### Adding the New Option to the Row Element
 
@@ -72,18 +72,18 @@ function custom_row_style_attributes( $attributes, $args ) {
 add_filter('siteorigin_panels_row_style_attributes', 'custom_row_style_attributes', 10, 2);
 ```
 
-The code checks if parallax is set inside the ``$args`` array and adds a value of 'parallax' to ``$attributes['class']``.
+The code checks if parallax is set inside the `$args` array and adds a value of 'parallax' to `$attributes['class']`.
 
-``$args`` array is used to check which values have been set.
-``$attributes`` array contains all the values that will display on the front-end.
+`$args` array is used to check which values have been set.
+`$attributes` array contains all the values that will display on the front-end.
 
-To add a custom class, append the class name to ``$attributes['class']``.
+To add a custom class, append the class name to `$attributes['class']`.
 
-To add a custom style (like text-align: center;), append the style to ``$attributes['style']``.
+To add a custom style (like text-align: center;), append the style to `$attributes['style']`.
 
-To add a new attribute, add both a new key and value to ``$attributes``. Example: ``$attributes['data-video-id'] = $args['video-id'];`` will add ``data-video-id="9"`` to the row element.
+To add a new attribute, add both a new key and value to `$attributes`. Example: `$attributes['data-video-id'] = $args['video-id'];` will add `data-video-id="9"` to the row element.
 
-Note that the filter for ``siteorigin_panels_row_style_attributes`` needs to be called after Page Builder loads. In my project I added the filter inside a function which is triggered on ``plugins_loaded``.
+Note that the filter for `siteorigin_panels_row_style_attributes` needs to be called after Page Builder loads. In my project I added the filter inside a function which is triggered on `plugins_loaded`.
 
 ### Processing Styles
 

--- a/page-builder/hooks/filtering-row-styles.md
+++ b/page-builder/hooks/filtering-row-styles.md
@@ -106,37 +106,3 @@ The current type. This parameter is not present if `siteorigin_panels_general_cu
 **args**
 
 An array containing builder arguments.
-
-### Altering the Default Number of Columns for Rows
-
-It's possible to override the default number of row columns, and their weight (width), by using the `siteorigin_panels_default_row_columns` filter. This filter accepts a multidimensional array with each item being treated as a column. Each item must contain a weight item which is used to size the column. Weight is decimal based so 0.30 is equivalent to 30% of the row.
-
-The following snippet will allow you to set the default:
-
-```php
-add_filter( 'siteorigin_panels_default_row_columns', function( $default_columns ) {
-	return array(
-		array(
-			'weight' => 0.333,
-		),
-		array(
-			'weight' => 0.333,
-		),
-		array(
-			'weight' => 0.333,
-		),
-	);
-} );
-```
-
-### Override the Row Column Input
-
-It's possible to adjust the Row Column input markup by using the `siteorigin_panels_row_column_count_input` filter. This will allow alter the column number present in the input field. It doesn't however allow you to alter the default row columns, that's done using `siteorigin_panels_default_row_columns` filter.
-
-The following snippet will column the column field to 4.
-
-```php
-add_filter( 'siteorigin_panels_row_column_count_input', function( $input ) {
-	return '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="4" />';
-} );
-```

--- a/page-builder/hooks/filtering-row-styles.md
+++ b/page-builder/hooks/filtering-row-styles.md
@@ -1,13 +1,13 @@
 ### Adding a Custom Option Under the Row Styles
 
 ```php
-function custom_row_style_fields($fields) {
+function custom_row_style_fields( $fields ) {
 	$fields['parallax'] = array(
-		'name'        => __('Parallax', 'siteorigin-panels'),
-		'type'        => 'checkbox',
-		'group'       => 'design',
-		'description' => __('If enabled, the background image will have a parallax effect.', 'siteorigin-panels'),
-		'priority'    => 8,
+		'name' => __( 'Parallax', 'so-widgets-test' ),
+		'type' => 'checkbox',
+		'group' => 'design',
+		'description' => __( 'If enabled, the background image will have a parallax effect.', 'so-widgets-test' ),
+		'priority' => 8,
 	);
 
 	return $fields;
@@ -62,14 +62,14 @@ Design Fields
 
 ```php
 function custom_row_style_attributes( $attributes, $args ) {
-	if ( !empty( $args['parallax'] ) ) {
-		array_push($attributes['class'], 'parallax');
+	if ( ! empty( $args['parallax'] ) ) {
+		array_push( $attributes['class'], 'parallax' );
 	}
 
 	return $attributes;
 }
 
-add_filter('siteorigin_panels_row_style_attributes', 'custom_row_style_attributes', 10, 2);
+add_filter( 'siteorigin_panels_row_style_attributes', 'custom_row_style_attributes', 10, 2 );
 ```
 
 The code checks if parallax is set inside the `$args` array and adds a value of 'parallax' to `$attributes['class']`.
@@ -107,7 +107,7 @@ The current type. This parameter is not present if `siteorigin_panels_general_cu
 
 An array containing builder arguments.
 
-### JavaScript event: setup_style_fields
+### JavaScript Event: setup_style_fields
 
 The `setup_style_fields` event will allow you interact with styles, and make adjustments based on the overall Page Builder view. This can be used to help trigger JavaScript assoicated with custom fields (such as date picker) and conditionally show fields.
 

--- a/page-builder/hooks/filtering-widget-styles.md
+++ b/page-builder/hooks/filtering-widget-styles.md
@@ -1,4 +1,4 @@
-### Filtering Widget Settings Based on Widget Being Edited
+### Filtering Widget Styles Based on Widget Being Edited
 
 As of SiteOrigin Page Builder `2.12.2`, it's possible to filter the Widget Styles available on a widget by widget basis. This is done using the `siteorigin_panels_widget_style_fields` filter, which has an optional parameter called `$args`, which contains additional information about the current styles. When editing a widget, `$args['widget']` will be set to the currently active Widget Class.
 

--- a/page-builder/hooks/override-row-collapse-point.md
+++ b/page-builder/hooks/override-row-collapse-point.md
@@ -36,7 +36,7 @@ add_filter( 'siteorigin_panels_css_row_collapse_point', function( $collapse_poin
 
 ### Dedicated Collapse Point Row Setting
 
-The following snippet will allow you to set a Collapse Point on a row by row basis using the Page Builder interface. This snippet makes use of `siteorigin_panels_row_style_fields` filter which is outlined on the [Custom Row Options Hooks](custom-row-settings.md) page.
+The following snippet will allow you to set a Collapse Point on a row by row basis using the Page Builder interface. This snippet makes use of `siteorigin_panels_row_style_fields` filter which is outlined on the [Custom Row Options Hooks](filtering-row-styles.md) page.
 
 ```php
 // Add in collapse point input field.

--- a/page-builder/hooks/row-form.md
+++ b/page-builder/hooks/row-form.md
@@ -1,0 +1,33 @@
+### Filter: siteorigin_panels_default_row_columns
+
+It's possible to override the default number of row columns, and their weight (width), by using the `siteorigin_panels_default_row_columns` filter. This filter accepts a multidimensional array with each item being treated as a column. Each item must contain a weight item which is used to size the column. Weight is decimal based so 0.30 is equivalent to 30% of the row.
+
+The following snippet will allow you to set the default:
+
+```php
+add_filter( 'siteorigin_panels_default_row_columns', function( $default_columns ) {
+	return array(
+		array(
+			'weight' => 0.333,
+		),
+		array(
+			'weight' => 0.333,
+		),
+		array(
+			'weight' => 0.333,
+		),
+	);
+} );
+```
+
+### Filter: siteorigin_panels_row_column_count_input
+
+It's possible to adjust the Row Column input markup by using the `siteorigin_panels_row_column_count_input` filter. This will allow alter the column number present in the input field. It doesn't however allow you to alter the default row columns, that's done using `siteorigin_panels_default_row_columns` filter.
+
+The following snippet will column the column field to 4.
+
+```php
+add_filter( 'siteorigin_panels_row_column_count_input', function( $input ) {
+	return '<input type="number" min="1" max="12" name="cells" class="so-row-field" value="4" />';
+} );
+```


### PR DESCRIPTION
This PR does the following:

- Renames custom-row-settings.md to filtering-row-styles.md.
- Renames filtering-widget-settings.md to filtering-widget-styles.md).
- Moves documentation covering row form settings to a newly introduced `page-builder/row-form.md`.
- Documents https://github.com/siteorigin/siteorigin-panels/pull/916 in filtering-row-styles.md

The renames and movement of documentation were done to cut down on the length of filtering-row-styles.md and make the file naming more consistent. row-form.md was introduced to be more consistent with widget-form.md.