### PR TITLE
Mention `tpl/default.php`

### DIFF
--- a/widgets-bundle/advanced-concepts/filters/template-file.md
+++ b/widgets-bundle/advanced-concepts/filters/template-file.md
@@ -1,21 +1,21 @@
-# Template file filter
+# Template File Filter
 
-This filter gives you a way to change which file is being used to render/display your widget. By default, Widgets Bundle will look for a file in your template directory called `default.php` in the `tpl` directory and this filter will allow you to change it to something else.
+This filter gives you a way to change which file is being used to render/display your widget. By default, Widgets Bundle will look for a file in your template directory called `default.php` in the `tpl` directory, and this filter will allow you to change it to something else.
 
-This filter perfect for conditional templates based on settings and as an example of that we've written a guide called [extending existing widgets](../../getting-started/extending-existing-widgets.md) that outlines this usecase.
+This filter is perfect for conditional templates based on settings, and as an example of that, we've written a guide called [extending existing widgets](../../getting-started/extending-existing-widgets.md) that outlines this use case.
 
 This filter has the form `'siteorigin_widgets_template_file_' . $this->id_base`, where id_base is the ID of the widget.
 
 ```php
 function mytheme_button_template_file( $filename, $instance, $widget ){
-    if ( ! empty( $instance['design']['theme'] ) && $instance['design']['theme'] == 'test' ) {
-        // This option works for plugins
-        $filename = plugin_dir_path( __FILE__ ) . 'tpl/button.php';
-        
-        // And this one for themes
-        $filename = get_stylesheet_dir() . '/tpl/button.php'; 
-    }
-    return $filename;
+	if ( ! empty( $instance['design']['theme'] ) && $instance['design']['theme'] == 'test' ) {
+		// This option works for plugins.
+		$filename = plugin_dir_path( __FILE__ ) . 'tpl/button.php';
+		
+		// And this one for themes.
+		$filename = get_stylesheet_dir() . '/tpl/button.php'; 
+	}
+	return $filename;
 }
 add_filter( 'siteorigin_widgets_template_file_sow-button', 'mytheme_button_template_file', 10, 3 );
 ```

--- a/widgets-bundle/advanced-concepts/filters/template-file.md
+++ b/widgets-bundle/advanced-concepts/filters/template-file.md
@@ -1,12 +1,14 @@
 # Template file filter
 
-This filter gives you a way to change which file is being used to render/display your widget. We use this filter in our section on [extending existing widgets](../../getting-started/extending-existing-widgets.md). This guide will give you the best idea of what this filter is for and how you'll likely be using it.
+This filter gives you a way to change which file is being used to render/display your widget. By default, Widgets Bundle will look for a file in your template directory called `default.php` in the `tpl` directory and this filter will allow you to change it to something else.
+
+This filter perfect for conditional templates based on settings and as an example of that we've written a guide called [extending existing widgets](../../getting-started/extending-existing-widgets.md) that outlines this usecase.
 
 This filter has the form `'siteorigin_widgets_template_file_' . $this->id_base`, where id_base is the ID of the widget.
 
 ```php
 function mytheme_button_template_file( $filename, $instance, $widget ){
-    if( !empty($instance['design']['theme']) && $instance['design']['theme'] == 'test' ) {
+    if ( ! empty( $instance['design']['theme'] ) && $instance['design']['theme'] == 'test' ) {
         // This option works for plugins
         $filename = plugin_dir_path( __FILE__ ) . 'tpl/button.php';
         

--- a/widgets-bundle/getting-started/creating-a-widget.md
+++ b/widgets-bundle/getting-started/creating-a-widget.md
@@ -98,9 +98,9 @@ Once you have implemented your widget like the above example, your widget will b
 
 You need to provide a template to tell the widget how it should be displayed. By default, Widgets Bundle will attempt to use `tpl/default.php` in your widget directory.
 
-You optionally supply a custom template name by overriding the `get_template_name` function and returning the name of the template file, without a `.php` file extension. By default, the base `SiteOrigin_Widget` class looks for a PHP file, with the name returned by `get_template_name`, in a `tpl` directory, in the widget directory.
+You optionally supply a custom template name by overriding the `get_template_name` function and returning the name of the template file without a `.php` file extension. By default, the base `SiteOrigin_Widget` class looks for a PHP file, with the name returned by `get_template_name`, in a `tpl` directory, in the widget directory.
 
-You can change what directory Widgets Bundle looks in by overriding the `get_template_dir` function and returning the path of a directory (without leading or trailing slashes), relative to the widget class file.
+You can change what the directory Widgets Bundle looks in by overriding the `get_template_dir` function and returning the path of a directory (without leading or trailing slashes) relative to the widget class file.
 
 ```php
 function get_template_name( $instance ) {

--- a/widgets-bundle/getting-started/creating-a-widget.md
+++ b/widgets-bundle/getting-started/creating-a-widget.md
@@ -96,7 +96,11 @@ Once you have implemented your widget like the above example, your widget will b
 
 ## Widget Template
 
-You need to provide a template to tell the widget how it should be displayed. You supply a template name by overriding the `get_template_name` function and returning the name of the template file, without a `.php` file extension. By default, the base `SiteOrigin_Widget` class looks for a PHP file, with the name returned by `get_template_name`, in a `tpl` directory, in the widget directory. You can change this behaviour by overriding the `get_template_dir` function and returning the path of a directory (without leading or trailing slashes), relative to the widget class file.
+You need to provide a template to tell the widget how it should be displayed. By default, Widgets Bundle will attempt to use `tpl/default.php` in your widget directory.
+
+You optionally supply a custom template name by overriding the `get_template_name` function and returning the name of the template file, without a `.php` file extension. By default, the base `SiteOrigin_Widget` class looks for a PHP file, with the name returned by `get_template_name`, in a `tpl` directory, in the widget directory.
+
+You can change what directory Widgets Bundle looks in by overriding the `get_template_dir` function and returning the path of a directory (without leading or trailing slashes), relative to the widget class file.
 
 ```php
 function get_template_name( $instance ) {

--- a/widgets-bundle/templating/html-templates.md
+++ b/widgets-bundle/templating/html-templates.md
@@ -1,5 +1,7 @@
 # HTML Templates
-HTML templates are used to render widgets for display in the front end. A template is included for output when the `widget()` function is called, so it has access to the widget `$instance` variable and the `$args` variable. The template's name must be specified by overriding the `get_template_name()` function. By default, it must be placed in a folder named _tpl_ in the root of the widget folder.
+HTML templates are used to render widgets for display in the front end. A template is included for output when the `widget()` function is called, so it has access to the widget `$instance` variable and the `$args` variable. By default, Widgets Bundle will attempt to use `tpl/default.php` in your widget directory.
+
+The template's name can be optionally overriden by using the `get_template_name()` function. By default, it must be placed in a folder named _tpl_ in the root of the widget folder.
 
 ### Example - simple template
 Overriding the `get_template_name()` function:

--- a/widgets-bundle/templating/html-templates.md
+++ b/widgets-bundle/templating/html-templates.md
@@ -1,85 +1,85 @@
 # HTML Templates
-HTML templates are used to render widgets for display in the front end. A template is included for output when the `widget()` function is called, so it has access to the widget `$instance` variable and the `$args` variable. By default, Widgets Bundle will attempt to use `tpl/default.php` in your widget directory.
+HTML templates are used to render widgets for display on the front end. A template is included for output when the `widget()` function is called, so it has access to the widget `$instance` variable and the `$args` variable. By default, Widgets Bundle will attempt to use `tpl/default.php` in your widget directory.
 
-The template's name can be optionally overriden by using the `get_template_name()` function. By default, it must be placed in a folder named _tpl_ in the root of the widget folder.
+The template's name can be optionally overridden by using the `get_template_name()` function. By default, it must be placed in a folder named _tpl_ in the root of the widget folder.
 
-### Example - simple template
+### Example - Simple Template
 Overriding the `get_template_name()` function:
 ```php
 function get_template_name( $instance ) {
-    return 'my-awesome-template';
+	return 'my-awesome-template';
 }
 ```
 
 In the file found at tpl/my-awesome-template.php:
 ```php
 <div>
-    <?php echo $args['before_title'] ?>
-    <h1><?php echo $instance['title'] ?></h1>
-    <?php echo $args['after_title'] ?>
-    <div>
-        <a href="<?php $instance['link_url'] ?>"><?php $instance['link_text'] ?></a>
-    </div>
+	<?php echo $args['before_title'] ?>
+	<h1><?php echo $instance['title'] ?></h1>
+	<?php echo $args['after_title'] ?>
+	<div>
+		<a href="<?php $instance['link_url'] ?>"><?php $instance['link_text'] ?></a>
+	</div>
 </div>
 ```
 
-## Template selection
+## Template Selection
 A template may be selected at runtime based on an option specified by the user, found in the `$instance` argument passed in to the `get_template_name()` function.
 
-### Example - template selection based on user input
+### Example - Template Selection Based on User Input
 ```php
 function get_template_name( $instance ) {
-    $template_name = '';
-    if( ! empty( $instance['use_blue_template'] ) ) {
-        $template_name = 'blue_template';
-    } else {
-        $template_name = 'red_template';
-    }
-    return $template_name;
+	$template_name = '';
+	if( ! empty( $instance['use_blue_template'] ) ) {
+		$template_name = 'blue_template';
+	} else {
+		$template_name = 'red_template';
+	}
+	return $template_name;
 }
 ```
 
-## Template variables
+## Template Variables
 For convenience, before including the template file specified by `get_template_name()`, the `SiteOrigin_Widget` base class extracts variables in the array returned by the `get_template_variables()` function. This is useful when it's necessary to perform any transformations on values specified by the user.
 
-### Example - using template variables
+### Example - Using Template Variables
 Return the variables for extraction in an array:
 ```php
 function get_template_variables( $instance, $args ) {
-    return array(
-        'title' => ! empty( $instance['title'] ) ? $instance['title'] : 'Default title',
-        'link_url' => ! empty( $instance['link_url'] ) ? $instance['link_url'] : '',
-        'link_text' => ! empty( $instance['link_text'] ) ? $instance['link_text'] : 'Default link text.',
-    );
+	return array(
+		'title' => ! empty( $instance['title'] ) ? $instance['title'] : 'Default title',
+		'link_url' => ! empty( $instance['link_url'] ) ? $instance['link_url'] : '',
+		'link_text' => ! empty( $instance['link_text'] ) ? $instance['link_text'] : 'Default link text.',
+	);
 }
 ```
 
 Use the extracted variable in a template:
 ```php
 <div>
-    <?php echo $args['before_title'] ?>
-    <h1><?php echo $title ?></h1>
-    <?php echo $args['after_title'] ?>
-    <div>
-        <a href="<?php $link_url ?>"><?php $link_text ?></a>
-    </div>
+	<?php echo $args['before_title'] ?>
+	<h1><?php echo $title ?></h1>
+	<?php echo $args['after_title'] ?>
+	<div>
+		<a href="<?php $link_url ?>"><?php $link_text ?></a>
+	</div>
 </div>
 ```
 
-## Escaping outputs
+## Escaping Outputs
 It is considered best practice to escape all potentially unsafe data as late as possible before outputting it to the front end. We strongly encourage this practice as it helps ensure security. The four built-in WordPress escaping functions (`esc_html`, `esc_url`, `esc_attr`, and `esc_js`) should be used as in the following example. More information on escaping data can be found <a href="http://codex.wordpress.org/Validating_Sanitizing_and_Escaping_User_Data#Escaping:_Securing_Output" target="_blank">here</a>.
 
-### Example - escaping data before output
+### Example - Escaping Data Before Output
 ```php
 <script type="text/javascript">
-    var value = <?php esc_js( $js_value ) ?>;
+	var value = <?php esc_js( $js_value ) ?>;
 </script>
 <div>
-    <?php echo esc_html( $args['before_title'] ) ?>
-    <h1><?php echo esc_html( $title ) ?></h1>
-    <?php echo esc_html( $args['after_title'] ) ?>
-    <div class="<?php esc_attr( $style_attribute ) ?>">
-        <a href="<?php esc_url( $link_url ) ?>"><?php esc_html( $link_text ) ?></a> 
-    </div>
+	<?php echo esc_html( $args['before_title'] ) ?>
+	<h1><?php echo esc_html( $title ) ?></h1>
+	<?php echo esc_html( $args['after_title'] ) ?>
+	<div class="<?php esc_attr( $style_attribute ) ?>">
+		<a href="<?php esc_url( $link_url ) ?>"><?php esc_html( $link_text ) ?></a> 
+	</div>
 </div>
 ```


### PR DESCRIPTION
This PR makes reference to the fact that Widgets Bundle will try to display `tpl/default.php` by default so you don't _need_ to specify a custom template name or directory.