### PR TITLE
Add Child Widgets doc page to developer docs

### DIFF
--- a/widgets-bundle/form-building/child-widgets.md
+++ b/widgets-bundle/form-building/child-widgets.md
@@ -1,0 +1,96 @@
+# Child Widgets
+
+Including a **child widget** (embedding one widget’s form and output inside another widget) lets you reuse existing widget functionality without duplicating form fields or front end code. A common example is the Call-to-Action widget, which embeds the Button widget instead of recreating every button field.
+
+## Defining a `widget` Form Field
+
+Add a field of **`type` => `widget`** to your widget’s `$form_options` array and specify the fully‑qualified PHP class name of the widget you want to embed.
+
+```php
+$form_options = array(
+	'button_field' => array(
+		'type'  => 'widget',
+		'label' => __( 'Button', 'siteorigin-docs' ),
+		'class' => 'SiteOrigin_Widget_Button_Widget',
+		'hide'  => true, // Start collapsed (optional).
+	),
+);
+```
+
+### Loading the Child Widget Class
+
+Make sure the child widget class is available **before** the parent form is built. For Widgets Bundle widgets:
+
+```php
+if ( ! class_exists( 'SiteOrigin_Widget_Button_Widget' ) ) {
+	SiteOrigin_Widgets_Bundle::single()->include_widget( 'button' );
+}
+```
+
+## Rendering the Child Widget on the Front‑End
+
+The child widget’s instance data is stored under the same key you used (`button_field` in this example). To output the widget inside your template:
+
+### Using `$wp_widget_factory`
+
+```php
+if ( ! empty( $instance['button_field'] ) ) {
+	global $wp_widget_factory;
+
+	$button_widget = $wp_widget_factory->widgets['SiteOrigin_Widget_Button_Widget'];
+
+	if ( $button_widget ) {
+		// Render the child widget without extra wrapper markup
+		$button_widget->widget( array(), $instance['button_field'] );
+	}
+}
+```
+
+### Using `the_widget()`
+
+```php
+the_widget( 'SiteOrigin_Widget_Button_Widget', $instance['button_field'] );
+```
+
+> **Note:** `the_widget()` adds a default `<div class="widget">` wrapper. Use `$wp_widget_factory` if you need full control over the markup.
+
+## Customizing the Child Widget Form
+
+Sometimes the child widget has fields that are irrelevant in your parent widget. You can remove or tweak these fields in two ways.
+
+### Overriding `modify_child_widget_form()`
+
+```php
+class My_Parent_Widget extends SiteOrigin_Widget {
+	function modify_child_widget_form( $child_form, $child_widget ) {
+		// Remove alignment controls from the Button widget.
+		unset( $child_form['design']['fields']['align'] );
+		unset( $child_form['design']['fields']['mobile_align'] );
+		return $child_form;
+	}
+}
+```
+
+### Using a `form_filter` Callback
+
+```php
+'button_field' => array(
+	'type'        => 'widget',
+	'class'       => 'SiteOrigin_Widget_Button_Widget',
+	'form_filter' => array( $this, 'filter_child_form' ),
+),
+
+function filter_child_form( $form, $child_widget ) {
+	unset( $form['design']['fields']['align'] );
+	return $form;
+}
+```
+
+## Examples in Core Widgets
+
+| Parent Widget  | Child Widget(s)     | File                                  |
+| -------------- | ------------------- | ------------------------------------- |
+| Call‑to‑Action | Button              | `widgets/cta/cta.php`                 |
+| Button Grid    | Repeater of Buttons | `widgets/button-grid/button-grid.php` |
+
+Browse these files in the Widgets Bundle source to see working implementations.

--- a/widgets-bundle/form-building/form-fields.md
+++ b/widgets-bundle/form-building/form-fields.md
@@ -753,7 +753,7 @@ Repeater containing two items (the first item is collapsed and the second item i
 ---
 
 ### widget
-Includes the entire form of an existing widget class.
+Includes the entire form of an existing widget class. You can [find more information about using child widgets here](./child-widgets.md).
 
 #### Additional Options
 - class: `string` The class name of the widget to be included.


### PR DESCRIPTION
* Introduces child-widgets.md:
  - Explains defining, loading, rendering, and customizing child widgets.
  - Includes code examples that match existing style guidelines.